### PR TITLE
swodlr-ui-table-color-bug: overrode table css classes

### DIFF
--- a/src/components/app/App.css
+++ b/src/components/app/App.css
@@ -311,6 +311,11 @@ tfoot {
   bottom: 0;
 }
 
+.table {
+  --bs-table-color: none;
+  --bs-table-bg: none;
+}
+
 .table-responsive-granulesion {
   max-height: 40vh;
   overflow-y: auto;

--- a/src/components/app/App.css
+++ b/src/components/app/App.css
@@ -316,7 +316,7 @@ tfoot {
   --bs-table-bg: none;
 }
 
-.table-responsive-granulesion {
+.table-responsive-granuleSelection {
   max-height: 40vh;
   overflow-y: auto;
 }


### PR DESCRIPTION
Changes### 

- fixed two bootstrap table classes not being overridden for text color and background color
- fixed spelling of a table class