### PR TITLE
Issues/59 - Update CICD to prepare for UAT deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           echo "THE_ENV=sit" >> $GITHUB_ENV
           echo "TARGET_ENV_UPPERCASE=SIT" >> $GITHUB_ENV
-          echo "THE_VERSION=$(npm --no-git-tag-version --allow-same-version version ${{ env.THE_VERSION }}-${GITHUB_SHA})" >> $GITHUB_ENV
+          echo "THE_VERSION=$(npm --no-git-tag-version --allow-same-version version ${{ steps.package-version.outputs.current-version }}-${GITHUB_SHA})" >> $GITHUB_ENV
       - name: Bump alpha version
         # If triggered by push to the develop branch
         if: ${{ github.ref == 'refs/heads/develop' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
     outputs:
       deploy_env: ${{ steps.npm-build.outputs.deploy_env }}
       deploy_env_lower: ${{ steps.npm-build.outputs.deploy_env_lower }}
-      version: ${{ steps.version.outputs.the_version }}
+      version: ${{ steps.npm-build.outputs.the_version }}
     steps:
       - uses: getsentry/action-github-app-token@v2
         name: my-app-install token
@@ -67,7 +67,7 @@ jobs:
         run: |
           echo "THE_ENV=sit" >> $GITHUB_ENV
           echo "TARGET_ENV_UPPERCASE=SIT" >> $GITHUB_ENV
-          echo "THE_VERSION=$(npm --no-git-tag-version --allow-same-version version ${{ steps.package-version.outputs.current-version }}-${GITHUB_SHA})" >> $GITHUB_ENV
+          echo "software_version=$(npm --no-git-tag-version --allow-same-version version ${{ steps.package-version.outputs.current-version }}-${GITHUB_SHA})" >> $GITHUB_ENV
       - name: Bump alpha version
         # If triggered by push to the develop branch
         if: ${{ github.ref == 'refs/heads/develop' }}
@@ -75,7 +75,7 @@ jobs:
         run: |
           echo "THE_ENV=sit" >> $GITHUB_ENV
           echo "TARGET_ENV_UPPERCASE=SIT" >> $GITHUB_ENV
-          echo "THE_VERSION=$(npm --no-git-tag-version version prerelease)" >> $GITHUB_ENV
+          echo "software_version=$(npm --no-git-tag-version version prerelease)" >> $GITHUB_ENV
       - name: Bump rc version
         # If triggered by push to a release branch
         if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
@@ -86,9 +86,9 @@ jobs:
           RELEASE_VERSION: ${THE_BRANCH//*\/}
         run: |
           if [ "$BUMP_RC" == true ]; then
-            echo "THE_VERSION=$(npm --no-git-tag-version version prerelease --preid rc)" >> $GITHUB_ENV
+            echo "software_version=$(npm --no-git-tag-version version prerelease --preid rc)" >> $GITHUB_ENV
           else
-            echo "THE_VERSION=$(npm --no-git-tag-version version ${GITHUB_REF#refs/heads/release/}-rc.1)" >> $GITHUB_ENV
+            echo "software_version=$(npm --no-git-tag-version version ${GITHUB_REF#refs/heads/release/}-rc.1)" >> $GITHUB_ENV
           fi
 
           echo "THE_ENV=uat" >> $GITHUB_ENV
@@ -102,15 +102,13 @@ jobs:
           echo "TARGET_ENV_UPPERCASE=OPS" >> $GITHUB_ENV
           echo "Modifying version number ${{ steps.package-version.outputs.current-version}}"
           THE_VERSION=${{ steps.package-version.outputs.current-version}}
-          echo "THE_VERSION=${THE_VERSION//-*}" >> $GITHUB_ENV
+          echo "software_version=${THE_VERSION//-*}" >> $GITHUB_ENV
           npm --no-git-tag-version version --allow-same-version ${THE_VERSION//-*}
       - name: No version bump
         # If triggered by workflow dispatch, no version bump
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          echo "software_version=$(poetry version | awk '{print $2}')" >> $GITHUB_ENV
           echo "TARGET_ENV_UPPERCASE=${{ github.event.inputs.venue }}" >> $GITHUB_ENV
-            # Setup Node to install and test
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
@@ -152,6 +150,7 @@ jobs:
           npm run build
           echo "deploy_env=${{ env.TARGET_ENV_UPPERCASE }}" >> $GITHUB_OUTPUT
           echo "deploy_env_lower=${{ env.THE_ENV }}" >> $GITHUB_OUTPUT
+          echo "the_version=${{ env.software_version }}" >> $GITHUB_OUTPUT
       - name: Upload package
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,13 @@ on:
   # Triggers the workflow on push events
   push:
     branches:
-    - main
-    - develop
-    - 'release/**'
-    - 'feature/**'
-    - 'issue/**'
-    - 'issues/**'
-    - 'dependabot/**'
+      - main
+      - develop
+      - 'release/**'
+      - 'feature/**'
+      - 'issue/**'
+      - 'issues/**'
+      - 'dependabot/**'
     tags-ignore:
       - '*'
     paths-ignore:
@@ -65,17 +65,17 @@ jobs:
           github.ref != 'refs/heads/main'    &&
           !startsWith(github.ref, 'refs/heads/release')
         run: |
-            echo "THE_ENV=sit" >> $GITHUB_ENV
-            echo "TARGET_ENV_UPPERCASE=SIT" >> $GITHUB_ENV
-            echo "THE_VERSION=$(npm --no-git-tag-version --allow-same-version version ${{ env.THE_VERSION }}-${GITHUB_SHA})" >> $GITHUB_ENV
+          echo "THE_ENV=sit" >> $GITHUB_ENV
+          echo "TARGET_ENV_UPPERCASE=SIT" >> $GITHUB_ENV
+          echo "THE_VERSION=$(npm --no-git-tag-version --allow-same-version version ${{ env.THE_VERSION }}-${GITHUB_SHA})" >> $GITHUB_ENV
       - name: Bump alpha version
         # If triggered by push to the develop branch
         if: ${{ github.ref == 'refs/heads/develop' }}
         id: alpha
         run: |
-            echo "THE_ENV=sit" >> $GITHUB_ENV
-            echo "TARGET_ENV_UPPERCASE=SIT" >> $GITHUB_ENV
-            echo "THE_VERSION=$(npm --no-git-tag-version version prerelease)" >> $GITHUB_ENV
+          echo "THE_ENV=sit" >> $GITHUB_ENV
+          echo "TARGET_ENV_UPPERCASE=SIT" >> $GITHUB_ENV
+          echo "THE_VERSION=$(npm --no-git-tag-version version prerelease)" >> $GITHUB_ENV
       - name: Bump rc version
         # If triggered by push to a release branch
         if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
@@ -98,12 +98,12 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/heads/main') }}
         id: release
         run: |
-            echo "THE_ENV=ops" >> $GITHUB_ENV
-            echo "TARGET_ENV_UPPERCASE=OPS" >> $GITHUB_ENV
-            echo "Modifying version number ${{ steps.package-version.outputs.current-version}}"
-            THE_VERSION=${{ steps.package-version.outputs.current-version}}
-            echo "THE_VERSION=${THE_VERSION//-*}" >> $GITHUB_ENV
-            npm --no-git-tag-version version --allow-same-version ${THE_VERSION//-*}
+          echo "THE_ENV=ops" >> $GITHUB_ENV
+          echo "TARGET_ENV_UPPERCASE=OPS" >> $GITHUB_ENV
+          echo "Modifying version number ${{ steps.package-version.outputs.current-version}}"
+          THE_VERSION=${{ steps.package-version.outputs.current-version}}
+          echo "THE_VERSION=${THE_VERSION//-*}" >> $GITHUB_ENV
+          npm --no-git-tag-version version --allow-same-version ${THE_VERSION//-*}
       - name: No version bump
         # If triggered by workflow dispatch, no version bump
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -123,14 +123,14 @@ jobs:
       - name: Run Snyk as a blocking step
         uses: snyk/actions/node@master
         env:
-            SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: test
           args: >
-              --org=${{ secrets.SNYK_ORG_ID }}
-              --project-name=${{ github.repository }}
-              --severity-threshold=high
-              --fail-on=all
+            --org=${{ secrets.SNYK_ORG_ID }}
+            --project-name=${{ github.repository }}
+            --severity-threshold=high
+            --fail-on=all
       - name: Run Snyk on Node
         uses: snyk/actions/node@master
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,15 +21,17 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
-      allow_same_version:
-        description: 'Allow the same version to be built'
-        required: false
-        default: 'false'
+      venue:
+        type: choice
+        description: Venue to deploy to
+        options:
+          - SIT
+          - UAT
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  PROJECT_ NAME: podaac/swodlr-ui
+  TERRAFORM_VERSION: "1.3.10"
 
 jobs:
   # First job in the workflow installs and verifies the software
@@ -39,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       deploy_env: ${{ steps.npm-build.outputs.deploy_env }}
+      deploy_env_lower: ${{ steps.npm-build.outputs.deploy_env_lower }}
       version: ${{ steps.version.outputs.the_version }}
     steps:
       - uses: getsentry/action-github-app-token@v2
@@ -47,55 +50,36 @@ jobs:
         with:
           app_id: ${{ secrets.CICD_APP_ID }}
           private_key: ${{ secrets.CICD_APP_PRIVATE_KEY }}
-
-      # Checkout
       - uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}
           token: ${{ steps.podaac-cicd.outputs.token }}
-
-      - name: Setup git user
-        run: |
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-
       - name: get-npm-version
         id: package-version
         uses: martinbeentjes/npm-get-version-action@v1.3.1
-
-      ## Set environment variables
-      - name: Configure Initial environment variables
-        run: |
-          echo "THE_VERSION=${{ steps.package-version.outputs.current-version}}" >> $GITHUB_ENV;
-          echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV;
-          GITHUB_REF_READABLE="${GITHUB_REF//\//-}"
-          echo "GITHUB_REF_READABLE=${GITHUB_REF_READABLE}" >> $GITHUB_ENV
-          echo "REACT_APP_SWODLR_API_BASE_URI=${{ env.REACT_APP_SWODLR_API_BASE_URI }}" >> $GITHUB_ENV;
-          echo "REACT_APP_DEV_REDIRECT_URI=${{ env.REACT_APP_DEV_REDIRECT_URI }}" >> $GITHUB_ENV;
-
       ## NPM Tagging
-      - name: Pre Alpha
+      - name: Bump pre-alpha version
+        # If triggered by push to a non-tracked branch
         if: |
-          startsWith(github.ref, 'refs/heads/issue') ||
-          startsWith(github.ref, 'refs/heads/dependabot/') ||
-          startsWith(github.ref, 'refs/heads/feature/')
+          github.ref != 'refs/heads/develop' &&
+          github.ref != 'refs/heads/main'    &&
+          !startsWith(github.ref, 'refs/heads/release')
         run: |
             echo "THE_ENV=sit" >> $GITHUB_ENV
             echo "TARGET_ENV_UPPERCASE=SIT" >> $GITHUB_ENV
             echo "THE_VERSION=$(npm --no-git-tag-version --allow-same-version version ${{ env.THE_VERSION }}-${GITHUB_SHA})" >> $GITHUB_ENV
-
-      ## Set Alpha variables
-      - name: Alpha
-        if: github.ref == 'refs/heads/develop'
+      - name: Bump alpha version
+        # If triggered by push to the develop branch
+        if: ${{ github.ref == 'refs/heads/develop' }}
+        id: alpha
         run: |
             echo "THE_ENV=sit" >> $GITHUB_ENV
             echo "TARGET_ENV_UPPERCASE=SIT" >> $GITHUB_ENV
             echo "THE_VERSION=$(npm --no-git-tag-version version prerelease)" >> $GITHUB_ENV
-
-      ## Bump RC Version
       - name: Bump rc version
         # If triggered by push to a release branch
         if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+        id: rc
         env:
           # True if the version already has a 'rc' pre-release identifier
           BUMP_RC: ${{ contains(steps.package-version.outputs.current-version, 'rc') }}
@@ -109,20 +93,10 @@ jobs:
 
           echo "THE_ENV=uat" >> $GITHUB_ENV
           echo "TARGET_ENV_UPPERCASE=UAT" >> $GITHUB_ENV
-
-      ## Set Release variables
-      - name: Release
-        if: ${{ (startsWith(github.ref, 'refs/heads/main')) && (github.event.inputs.allow_same_version != 'true') }}
-        run: |
-            echo "THE_ENV=ops" >> $GITHUB_ENV
-            echo "TARGET_ENV_UPPERCASE=OPS" >> $GITHUB_ENV
-            echo "Modifying version number ${{ steps.package-version.outputs.current-version}}"
-            THE_VERSION=${{ steps.package-version.outputs.current-version}}
-            echo "THE_VERSION=${THE_VERSION//-*}" >> $GITHUB_ENV
-            npm --no-git-tag-version version ${THE_VERSION//-*}
-
-      - name: Release - Allow same version
-        if: ${{ (startsWith(github.ref, 'refs/heads/main')) && (github.event.inputs.allow_same_version == 'true') }}
+      - name: Release version
+        # If triggered by push to the main branch
+        if: ${{ startsWith(github.ref, 'refs/heads/main') }}
+        id: release
         run: |
             echo "THE_ENV=ops" >> $GITHUB_ENV
             echo "TARGET_ENV_UPPERCASE=OPS" >> $GITHUB_ENV
@@ -130,7 +104,22 @@ jobs:
             THE_VERSION=${{ steps.package-version.outputs.current-version}}
             echo "THE_VERSION=${THE_VERSION//-*}" >> $GITHUB_ENV
             npm --no-git-tag-version version --allow-same-version ${THE_VERSION//-*}
-
+      - name: No version bump
+        # If triggered by workflow dispatch, no version bump
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "software_version=$(poetry version | awk '{print $2}')" >> $GITHUB_ENV
+          echo "TARGET_ENV_UPPERCASE=${{ github.event.inputs.venue }}" >> $GITHUB_ENV
+            # Setup Node to install and test
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+      - name: Validate Terraform
+        working-directory: terraform
+        run: |
+          terraform init -backend=false
+          terraform validate -no-color
       - name: Run Snyk as a blocking step
         uses: snyk/actions/node@master
         env:
@@ -142,7 +131,6 @@ jobs:
               --project-name=${{ github.repository }}
               --severity-threshold=high
               --fail-on=all
-
       - name: Run Snyk on Node
         uses: snyk/actions/node@master
         env:
@@ -152,36 +140,109 @@ jobs:
           args: >
             --org=${{ secrets.SNYK_ORG_ID }}
             --project-name=${{ github.repository }}
-
-      - name: Commit Version Bump
-        id: version
-        # If building develop, a release branch, or main then we commit the version bump back to the repo
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: NPM install & NPM Lint
+        id: npm-build
         run: |
-          if ${{ github.event.inputs.allow_same_version != 'true' &&
-                 (github.ref == 'refs/heads/develop' ||
-                  github.ref == 'refs/heads/main'    ||
-                  startsWith(github.ref, 'refs/heads/release')) }}; then
-            git commit -am "/version ${{ env.THE_VERSION }}"
-            git push
-          fi
-          echo "the_version=${{ env.THE_VERSION }}" >> $GITHUB_OUTPUT
-
-      - name: Push Tag
+          source terraform/environments/${{ env.THE_ENV }}.env
+          npm install
+          npm run build
+          echo "deploy_env=${{ env.TARGET_ENV_UPPERCASE }}" >> $GITHUB_OUTPUT
+          echo "deploy_env_lower=${{ env.THE_ENV }}" >> $GITHUB_OUTPUT
+      - name: Upload package
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: build/*
+      - name: Commit Version Bump
+        # If building an alpha, release candidate, or release then we commit the version bump back to the repo
         if: |
-          github.ref == 'refs/heads/develop' ||
-          github.ref == 'refs/heads/main'    ||
-          startsWith(github.ref, 'refs/heads/release')
+          steps.alpha.conclusion == 'success'   ||
+          steps.rc.conclusion == 'success'      ||
+          steps.release.conclusion == 'success'
         run: |
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git tag -f -a "${{ env.THE_VERSION }}" -m "Version ${{ env.THE_VERSION }}"
-          git push origin "${{ env.THE_VERSION }}" --force
-
+          git commit -am "/version ${{ env.software_version }}"
+          git push
+      - name: Push Tag
+        if: |
+          steps.alpha.conclusion == 'success'   ||
+          steps.rc.conclusion == 'success'      ||
+          steps.release.conclusion == 'success'
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git tag -a "${{ env.software_version }}" -m "Version ${{ env.software_version }}"
+          git push origin "${{ env.software_version }}"
+      - name: Create GH release
+        if: |
+          steps.alpha.conclusion == 'success'   ||
+          steps.rc.conclusion == 'success'      ||
+          steps.release.conclusion == 'success'
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          name: ${{ env.software_version }}
+          prerelease: ${{ steps.alpha.conclusion == 'success' || steps.rc.conclusion == 'success'}}
+          tag: ${{ env.software_version }}
+  deploy:
+    name: Deploy
+    needs: build
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    environment: ${{ needs.build.outputs.deploy_env }}
+    env:
+      THE_ENV: ${{ needs.build.outputs.deploy_env_lower }}
+      TARGET_ENV_UPPERCASE: ${{ needs.build.outputs.deploy_env }}
+      THE_VERSION: ${{ needs.build.outputs.version }}
+    if: |
+      github.ref == 'refs/heads/develop' ||
+      github.ref == 'refs/heads/main'    ||
+      startsWith(github.ref, 'refs/heads/release') ||
+      github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ github.repository }}
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-session-name: GitHubActions
+          aws-access-key-id: ${{ secrets[vars.AWS_ACCESS_KEY_ID_SECRET_NAME] }}
+          aws-secret-access-key: ${{ secrets[vars.AWS_SECRET_ACCESS_KEY_SECRET_NAME] }}
+          mask-aws-account-id: true
+      - name: Deploy to venue
+        id: terraform-deploy
+        working-directory: terraform/
+        env:
+          AWS_DEFAULT_REGION: us-west-2
+        run: |
+          export TF_VAR_cloudfront_distribution_id=${{ secrets.CF_DISTRIBUTION_ID }}
+          export TF_VAR_cloudfront_allow_vpcs=${{ secrets.EDC_INTERNET_SERVICES_VPCS }}
+          ./bin/deploy.sh --app-version ${{ env.THE_VERSION }} --tf-venue ${{ vars.TF_VENUE }}
+          echo "SWODLR_UI_BUCKET=$(terraform output -raw swodlr-bucket-name)" >> $GITHUB_ENV
+      - uses: actions/download-artifact@v3
+        id: download
+        with:
+          name: build
+          path: build/
+      - name: Sync S3
+        run:
+          aws s3 sync ${{steps.download.outputs.download-path}} s3://${{ env.SWODLR_UI_BUCKET }} --delete
       - name: Publish UMM-T with new version
         uses: podaac/cmr-umm-updater@0.5.0
         if: |
-          github.ref == 'refs/heads/main'    ||
-          startsWith(github.ref, 'refs/heads/release')
+          env.TARGET_ENV_UPPERCASE == 'UAT' ||
+          env.TARGET_ENV_UPPERCASE == 'OPS'
         with:
           umm-json: 'cmr/${{env.THE_ENV}}_swodlr_cmr_umm_t.json'
           provider: 'POCLOUD'
@@ -195,93 +256,3 @@ jobs:
           LAUNCHPAD_TOKEN_SIT: ${{secrets.LAUNCHPAD_TOKEN_SIT}}
           LAUNCHPAD_TOKEN_UAT: ${{secrets.LAUNCHPAD_TOKEN_UAT}}
           LAUNCHPAD_TOKEN_OPS: ${{secrets.LAUNCHPAD_TOKEN_OPS}}
-
-      # Setup Node to install and test
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - name: Deploy Env Override
-        if: |
-          github.event.head_commit.message == '/deploy sit' ||
-          github.event.head_commit.message == '/deploy uat'
-        run: |
-          message="${{ github.event.head_commit.message }}"
-          trimmed_message=${message:1}  # Remove leading slash
-          override_env=$(echo "$trimmed_message" | grep -oE '[^[:space:]]+$')
-          override_env_upper=$(echo "$trimmed_message" | awk '{print toupper($NF)}')
-          echo "THE_ENV=${override_env}" >> $GITHUB_ENV
-          echo "TARGET_ENV_UPPERCASE=${override_env_upper}" >> $GITHUB_ENV
-
-      - name: NPM install & NPM Lint
-        id: npm-build
-        run: |
-          source terraform/environments/${{ env.THE_ENV }}.env
-          npm install
-          npm run build
-          echo "deploy_env=${{ env.TARGET_ENV_UPPERCASE }}" >> $GITHUB_OUTPUT
-      - name: Upload package
-        uses: actions/upload-artifact@v3
-        with:
-          name: build
-          path: build/*
-
-      ## Deployment
-
-
-  deploy:
-    name: Deploy
-    needs: build
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    environment: ${{ needs.build.outputs.deploy_env }}
-    env:
-      TARGET_ENV_UPPERCASE: ${{ needs.build.outputs.deploy_env }}
-      THE_VERSION: ${{ needs.build.outputs.version }}
-    if: |
-      github.ref == 'refs/heads/develop' ||
-      github.ref == 'refs/heads/main'    ||
-      startsWith(github.ref, 'refs/heads/release') ||
-      github.event.head_commit.message == '/deploy sit' ||
-      github.event.head_commit.message == '/deploy uat'
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: ${{ github.repository }}
-      - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.3.7
-          terraform_wrapper: false
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-region: us-west-2
-          role-session-name: GitHubActions
-          aws-access-key-id: ${{ secrets[vars.AWS_ACCESS_KEY_ID_SECRET_NAME] }}
-          aws-secret-access-key: ${{ secrets[vars.AWS_SECRET_ACCESS_KEY_SECRET_NAME] }}
-
-      - name: Validate Terraform
-        run: terraform validate -no-color
-
-      - name: Deploy to venue
-        id: terraform-deploy
-        working-directory: terraform/
-        env:
-          AWS_DEFAULT_REGION: us-west-2
-        run: |
-          export TF_VAR_cloudfront_distribution_id=${{ secrets.CF_DISTRIBUTION_ID }}
-          export TF_VAR_cloudfront_allow_vpcs=${{ secrets.EDC_INTERNET_SERVICES_VPCS }}
-          ./bin/deploy.sh --app-version ${{ env.THE_VERSION }} --tf-venue ${{ vars.TF_VENUE }}
-          echo "SWODLR_UI_BUCKET=$(terraform output -raw swodlr-bucket-name)" >> $GITHUB_ENV
-
-      - uses: actions/download-artifact@v3
-        id: download
-        with:
-          name: build
-          path: build/
-
-      - name: Sync S3
-        run:
-          aws s3 sync ${{steps.download.outputs.download-path}} s3://${{ env.SWODLR_UI_BUCKET }} --delete


### PR DESCRIPTION
Closes #59 

Update the pipeline to more closely match our other projects. 

Removed the deploy by commit message and replaced instead with a workflow dispatch option. Now, develop, feature/, issue/, and issues/ branches can be deployed to SIT via the actions page for running the build workflow.

release/ branches can be deployed to UAT