### PR TITLE
Issues/swodlr UI final fixes - bug fixed before version 1.0 release

### DIFF
--- a/src/components/about/About.tsx
+++ b/src/components/about/About.tsx
@@ -148,6 +148,7 @@ const About = () => {
                                     {packageJson.version}
                                 </h5>
                             </Row>
+                            <Row><h5><a href="https://github.com/podaac/swodlr-ui/releases" target="_">{`(Release Notes)`}</a></h5></Row>
                         </ListGroup.Item>
                         <ListGroup.Item className='howToListItem' style={{marginRight: '0%', marginLeft: '0%'}}>
                             <Row>
@@ -156,17 +157,6 @@ const About = () => {
                                     {backendVersion}
                                 </h5>
                             </Row>
-                        </ListGroup.Item>
-                    </ListGroup>
-                </div>
-            </Row>
-
-            <Row className='about-card' style={{marginRight: '10%', marginLeft: '10%', marginBottom: '40px'}}>
-                <div className='howToListItem' style={{marginBottom: '20px', paddingRight: '5%', paddingLeft: '5%'}}>
-                    <h4 style={{marginTop: '10px', marginBottom: '20px'}}>Version History</h4>
-                    <ListGroup>
-                        <ListGroup.Item className='howToListItem' style={{marginRight: '0%', marginLeft: '0%'}}>
-                            <Row><h5><b>Version 1 Pre-Alpha</b> (9/05/2023)</h5></Row>
                         </ListGroup.Item>
                     </ListGroup>
                 </div>

--- a/src/components/about/About.tsx
+++ b/src/components/about/About.tsx
@@ -4,9 +4,19 @@ import CompareImage from '../../assets/comparing-images.png'
 import YukonImage from '../../assets/SWOT-YUKON.jpeg'
 import LatLongUTM from '../../assets/lat-lon-vs-utm.png'
 import UpSWOTResolution from '../../assets/swot-go-up-resolution.jpg'
+import packageJson from '../../../package.json'
+import { useEffect, useState } from "react";
 
 const About = () => {
-
+    const [backendVersion, setBackendVersion] = useState('')
+    useEffect(() => {
+        const fetchData = async () => {
+            setBackendVersion(await fetch('https://swodlr.podaac.sit.earthdatacloud.nasa.gov/api/about').then((version) => version.json()).then(response => response.version))
+        }
+        fetchData()
+        .catch(console.error);
+      }, []);
+      
     return (
         <Col className="about-page" style={{marginTop: '70px', paddingRight: '12px', marginLeft: '0px', height: '100%'}}>
             <Row><h4 style={{marginTop: '10px', marginBottom: '20px'}}>About: SWOT On-Demand Level-2 Raster Generator</h4></Row>
@@ -18,7 +28,7 @@ const About = () => {
                         SWODLR is an on-demand raster generation tool that generates customized Surface Water and Ocean Topography (SWOT) Level 2 raster products. SWOT standard products are released in geographically fixed tiles at 100m and 250m resolutions in a Universal Transverse Mercator (UTM) projection grid. SWODLR allows users to generate the same products at different resolutions in either the UTM or geodetic coordinate system (lat/lon). SWODLR also gives an option to change the output granule extent from a nonoverlapping square 128 km x 128 km to an overlapping rectangle 256 km x 128 km to assist with observing areas of interest near the along-track edges of the original square extent.
                     </h5>
                     <h5>
-                        Like the standard product, the on-demand product contains rasterized water surface elevation and inundation-extents. This is derived through resampling the upstream pixel cloud (L2_HR_PIXC) and pixel vector (L2_HR_PIXCVEC) datasets onto a uniform grid. A uniform grid is superimposed onto the pixel cloud from the source products, and all pixel-cloud samples within each grid cell are aggregated to produce a single value per raster cell. SWODLR uses the <a href='https://deotb6e7tfubr.cloudfront.net/s3-edaf5da92e0ce48fb61175c28b67e95d/podaac-ops-cumulus-docs.s3.us-west-2.amazonaws.com/web-misc/swot_mission_docs/atbd/D-105507_SWOT_ATBD_L2_HR_Raster_w-sigs.pdf?A-userid=None&Expires=1701977957&Signature=O8RO~hg2I0pIgH2wSebhos861vC9zG77fk-9LsTCzBnTbTysg1p56rUxOTLycm0M1TnRlwjo5jfLGOkyEpqj~x50J-cxUl16wS1c~pA327KSf8~LZ5170e-azmLUFOgYhACgl23A6qhF9KGhF6yX-Ba4oW756UMg33teMWAAkowFXbi0JOdzIr~bkIcONk7MTr~jzU9G-Tum-yDwk3PEh8ch0sW~9QCJGXq0BjIu6wAquU8bA9wbonqV76w5VrzOiR~42h8jYaNq0MJ18zLwZIWKYQIbXfKHqlm6tWJ6Cwd80QOMAPdEQ5AsF83bG1Q4TxzEgF-GZ8n4nLZlSQObgg__&Key-Pair-Id=K3CPO4G5OR7B1G' target="_">original algorithm</a> that standard SWOT products use to generate products but at a different resolution; it does not just re-grid the standard products.
+                        Like the standard product, the on-demand product contains rasterized water surface elevation and inundation-extents. This is derived through resampling the upstream pixel cloud (L2_HR_PIXC) and pixel vector (L2_HR_PIXCVEC) datasets onto a uniform grid. A uniform grid is superimposed onto the pixel cloud from the source products, and all pixel-cloud samples within each grid cell are aggregated to produce a single value per raster cell. SWODLR uses the <a href='https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-docs/web-misc/swot_mission_docs/atbd/D-105507_SWOT_ATBD_L2_HR_Raster_w-sigs.pdf' target="_">original algorithm</a> that standard SWOT products use to generate products but at a different resolution; it does not just re-grid the standard products.
                     </h5>
                 </div>
             </Row>
@@ -69,8 +79,6 @@ const About = () => {
                     </ListGroup>
                 </div>
             </Row>
-
-            {/* <Row className='about-card'><h4 style={{marginTop: '10px', marginBottom: '20px'}}>FAQ</h4></Row> */}
 
             <Row className='about-card' style={{marginRight: '10%', marginLeft: '10%', marginBottom: '40px'}}>
                 <div className='about-card' style={{paddingTop: '20px', paddingBottom: '30px', paddingRight: '5%', paddingLeft: '5%'}}>
@@ -131,10 +139,34 @@ const About = () => {
 
             <Row className='about-card' style={{marginRight: '10%', marginLeft: '10%', marginBottom: '40px'}}>
                 <div className='howToListItem' style={{marginBottom: '20px', paddingRight: '5%', paddingLeft: '5%'}}>
+                    <h4 style={{marginTop: '10px', marginBottom: '20px'}}>Current Version</h4>
+                    <ListGroup>
+                        <ListGroup.Item className='howToListItem' style={{marginRight: '0%', marginLeft: '0%'}}>
+                            <Row>
+                                <h5>
+                                    <b>SWODLR UI: </b> 
+                                    {packageJson.version}
+                                </h5>
+                            </Row>
+                        </ListGroup.Item>
+                        <ListGroup.Item className='howToListItem' style={{marginRight: '0%', marginLeft: '0%'}}>
+                            <Row>
+                                <h5>
+                                    <b>SWODLR API: </b>
+                                    {backendVersion}
+                                </h5>
+                            </Row>
+                        </ListGroup.Item>
+                    </ListGroup>
+                </div>
+            </Row>
+
+            <Row className='about-card' style={{marginRight: '10%', marginLeft: '10%', marginBottom: '40px'}}>
+                <div className='howToListItem' style={{marginBottom: '20px', paddingRight: '5%', paddingLeft: '5%'}}>
                     <h4 style={{marginTop: '10px', marginBottom: '20px'}}>Version History</h4>
                     <ListGroup>
                         <ListGroup.Item className='howToListItem' style={{marginRight: '0%', marginLeft: '0%'}}>
-                            <Row><h5><b>Version 1</b> (9/05/2023)</h5></Row>
+                            <Row><h5><b>Version 1 Pre-Alpha</b> (9/05/2023)</h5></Row>
                         </ListGroup.Item>
                     </ListGroup>
                 </div>

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -60,7 +60,8 @@ const App = () => {
       navigate(`/customizeProduct/selectScenes?cyclePassScene=9_515_130&showUTMAdvancedOptions=true`)
     } else if (stepTarget === '#customization-tab' && action === 'start') {
       navigate('/customizeProduct/selectScenes')
-    } else if ((stepTarget === '#generate-products-button' && action === 'close' && lifecycle === 'complete') || (stepTarget === '#my-data-page' && action === 'next')) {
+    // } else if ((stepTarget === '#generate-products-button' && action === 'close' && lifecycle === 'complete') || (stepTarget === '#my-data-page' && action === 'next')) {
+    } else if ((action === 'next' || action === 'close') && stepTarget === '#my-data-page') {
       navigate(`/generatedProductHistory${search}`)
     } else if (type === 'tour:end') {
       dispatch(setSkipTutorialTrue())

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -18,7 +18,8 @@ import Joyride, { ACTIONS, EVENTS } from 'react-joyride';
 import { deleteProduct } from '../sidebar/actions/productSlice';
 import { tutorialSteps } from '../tutorial/tutorialConstants';
 import InteractiveTutorialModal from '../tutorial/InteractiveTutorialModal';
-import { setSkipTutorialTrue } from '../sidebar/actions/modalSlice';
+import { setShowCloseTutorialTrue, setSkipTutorialTrue } from '../sidebar/actions/modalSlice';
+import InteractiveTutorialModalClose from '../tutorial/InteractiveTutorialModalClose';
 
 const App = () => {
   const dispatch = useAppDispatch()
@@ -53,10 +54,7 @@ const App = () => {
     }
 
     if (action === 'close') {
-      dispatch(setSkipTutorialTrue())
-      dispatch(setStartTutorial(false))
-      dispatch(deleteProduct(addedProducts.map(product => product.granuleId)))
-      navigate(`/customizeProduct/selectScenes`)
+      dispatch(setShowCloseTutorialTrue())
     } else if (stepTarget === '#configure-options-breadcrumb' && action === 'update') {
       navigate(`/customizeProduct/configureOptions${search}`)
     } else if (stepTarget === '#configure-options-breadcrumb' && action === 'prev' && lifecycle === 'complete') {
@@ -120,8 +118,6 @@ const App = () => {
         steps={joyride.steps}
         stepIndex={joyride.stepIndex}
         showProgress
-        // showSkipButton
-        // hideCloseButton
         continuous
         scrollToFirstStep
       />
@@ -135,6 +131,7 @@ const App = () => {
         <Route path='*' element={getPageWithFormatting(<NotFound errorCode='404'/>, true)}/>
       </Routes>
       <InteractiveTutorialModal />
+      <InteractiveTutorialModalClose />
     </div>
   );
 }

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -14,10 +14,11 @@ import { Session } from '../../authentication/session';
 import { getCurrentUser, setStartTutorial } from './appSlice';
 import { useEffect, useState } from 'react';
 import GranuleSelectionAndConfigurationView from '../sidebar/GranuleSelectionAndConfigurationView';
-import Joyride, { ACTIONS, EVENTS, STATUS } from 'react-joyride';
+import Joyride, { ACTIONS, EVENTS } from 'react-joyride';
 import { deleteProduct } from '../sidebar/actions/productSlice';
 import { tutorialSteps } from '../tutorial/tutorialConstants';
 import InteractiveTutorialModal from '../tutorial/InteractiveTutorialModal';
+import { setSkipTutorialTrue } from '../sidebar/actions/modalSlice';
 
 const App = () => {
   const dispatch = useAppDispatch()
@@ -36,8 +37,10 @@ const App = () => {
     steps: tutorialSteps,
     stepIndex: 0
   })
+  
   useEffect(() => {
-    setState({...joyride, run: startTutorial })
+    setState({...joyride, run: startTutorial, stepIndex: 0})
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [startTutorial]);
 
   const handleJoyrideCallback = (data: { action: any; index: any; status: any; type: any; step: any; lifecycle: any; }) => {
@@ -60,8 +63,9 @@ const App = () => {
     } else if ((stepTarget === '#generate-products-button' && action === 'close' && lifecycle === 'complete') || (stepTarget === '#my-data-page' && action === 'next')) {
       navigate(`/generatedProductHistory${search}`)
     } else if (type === 'tour:end') {
-      dispatch(deleteProduct(addedProducts.map(product => product.granuleId)))
+      dispatch(setSkipTutorialTrue())
       dispatch(setStartTutorial(false))
+      dispatch(deleteProduct(addedProducts.map(product => product.granuleId)))
       navigate(`/customizeProduct/selectScenes`)
     }
   };

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -59,9 +59,11 @@ const App = () => {
       navigate(`/customizeProduct/configureOptions${search}`)
     } else if (stepTarget === '#configure-options-breadcrumb' && action === 'prev' && lifecycle === 'complete') {
       navigate(`/customizeProduct/selectScenes${search}`)
-    } else if (stepTarget === '#my-data-page' && action === 'prev') {
+    }
+     else if (stepTarget === '#my-data-page' && action === 'prev' && lifecycle === 'complete') {
       navigate(`/customizeProduct/configureOptions${search}`)
-    } else if (stepTarget === '#added-scenes' && action === 'update') {
+    }
+     else if (stepTarget === '#added-scenes' && action === 'update') {
       navigate(`/customizeProduct/selectScenes?cyclePassScene=9_515_130&showUTMAdvancedOptions=true`)
     } else if (stepTarget === '#customization-tab' && action === 'start') {
       navigate('/customizeProduct/selectScenes')

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -57,7 +57,7 @@ const App = () => {
     } else if (stepTarget === '#my-data-page' && action === 'prev') {
       navigate(`/customizeProduct/configureOptions${search}`)
     } else if (stepTarget === '#added-scenes' && action === 'update') {
-      navigate(`/customizeProduct/selectScenes?cyclePassScene=1_414_20&showUTMAdvancedOptions=true`)
+      navigate(`/customizeProduct/selectScenes?cyclePassScene=9_515_130&showUTMAdvancedOptions=true`)
     } else if (stepTarget === '#customization-tab' && action === 'start') {
       navigate('/customizeProduct/selectScenes')
     } else if ((stepTarget === '#generate-products-button' && action === 'close' && lifecycle === 'complete') || (stepTarget === '#my-data-page' && action === 'next')) {

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -46,11 +46,18 @@ const App = () => {
   const handleJoyrideCallback = (data: { action: any; index: any; status: any; type: any; step: any; lifecycle: any; }) => {
     const { action, step, type, lifecycle, index } = data;
     const stepTarget = step.target
+
     if ([EVENTS.STEP_AFTER, EVENTS.TARGET_NOT_FOUND].includes(type)) {
       // Update state to advance the tour
       setState({...joyride, stepIndex: index + (action === ACTIONS.PREV ? -1 : 1) });
     }
-    if (stepTarget === '#configure-options-breadcrumb' && action === 'update') {
+
+    if (action === 'close') {
+      dispatch(setSkipTutorialTrue())
+      dispatch(setStartTutorial(false))
+      dispatch(deleteProduct(addedProducts.map(product => product.granuleId)))
+      navigate(`/customizeProduct/selectScenes`)
+    } else if (stepTarget === '#configure-options-breadcrumb' && action === 'update') {
       navigate(`/customizeProduct/configureOptions${search}`)
     } else if (stepTarget === '#configure-options-breadcrumb' && action === 'prev' && lifecycle === 'complete') {
       navigate(`/customizeProduct/selectScenes${search}`)
@@ -60,8 +67,7 @@ const App = () => {
       navigate(`/customizeProduct/selectScenes?cyclePassScene=9_515_130&showUTMAdvancedOptions=true`)
     } else if (stepTarget === '#customization-tab' && action === 'start') {
       navigate('/customizeProduct/selectScenes')
-    // } else if ((stepTarget === '#generate-products-button' && action === 'close' && lifecycle === 'complete') || (stepTarget === '#my-data-page' && action === 'next')) {
-    } else if ((action === 'next' || action === 'close') && stepTarget === '#my-data-page') {
+    } else if (action === 'next' && stepTarget === '#my-data-page') {
       navigate(`/generatedProductHistory${search}`)
     } else if (type === 'tour:end') {
       dispatch(setSkipTutorialTrue())
@@ -114,8 +120,8 @@ const App = () => {
         steps={joyride.steps}
         stepIndex={joyride.stepIndex}
         showProgress
-        showSkipButton
-        hideCloseButton
+        // showSkipButton
+        // hideCloseButton
         continuous
         scrollToFirstStep
       />

--- a/src/components/app/appSlice.ts
+++ b/src/components/app/appSlice.ts
@@ -9,7 +9,8 @@ interface AppState {
   userAuthenticated: boolean,
   currentPage: PageTypes,
   currentUser: CurrentUserData | null,
-  startTutorial: boolean
+  startTutorial: boolean,
+  userHasCorrectEdlPermissions: boolean
 }
 
 export const getCurrentUser = createAsyncThunk<CurrentUserData | null>('currentUser', async () => {
@@ -21,7 +22,8 @@ const initialState: AppState = {
   userAuthenticated: false,
   currentPage: 'welcome',
   currentUser: null,
-  startTutorial: false
+  startTutorial: false,
+  userHasCorrectEdlPermissions: false
 }
 
 export const appSlice = createSlice({
@@ -36,6 +38,9 @@ export const appSlice = createSlice({
     },
     setStartTutorial: (state, action: PayloadAction<boolean>) => {
       state.startTutorial = action.payload
+    },
+    setUserHasCorrectEdlPermissions: (state, action: PayloadAction<boolean>) => {
+      state.userHasCorrectEdlPermissions = action.payload
     },
   },
   extraReducers(builder) {
@@ -55,6 +60,6 @@ export const appSlice = createSlice({
   },
 });
 
-export const { logoutCurrentUser, setStartTutorial } = appSlice.actions
+export const { logoutCurrentUser, setStartTutorial, setUserHasCorrectEdlPermissions } = appSlice.actions
 
 export default appSlice.reducer

--- a/src/components/app/appSlice.ts
+++ b/src/components/app/appSlice.ts
@@ -23,7 +23,7 @@ const initialState: AppState = {
   currentPage: 'welcome',
   currentUser: null,
   startTutorial: false,
-  userHasCorrectEdlPermissions: false
+  userHasCorrectEdlPermissions: true
 }
 
 export const appSlice = createSlice({

--- a/src/components/app/appSlice.ts
+++ b/src/components/app/appSlice.ts
@@ -1,5 +1,5 @@
 import { PayloadAction, createAsyncThunk, createSlice } from '@reduxjs/toolkit'
-import { PageTypes, UserData } from '../../types/constantTypes'
+import { PageTypes } from '../../types/constantTypes'
 import { CurrentUserData } from '../../types/graphqlTypes'
 import { Session } from '../../authentication/session';
 import { getUserData } from '../../user/userData';

--- a/src/components/edl/AuthorizationCodeHandler.tsx
+++ b/src/components/edl/AuthorizationCodeHandler.tsx
@@ -5,6 +5,46 @@ import { exchangeAuthenticationCode } from "../../authentication/edl";
 import { OAuthTokenExchangeFailed } from "../../authentication/exception";
 import { Session } from "../../authentication/session";
 
+import { spatialSearchCollectionConceptId, spatialSearchResultLimit } from "../../constants/rasterParameterConstants";
+
+export const checkUseHasCorrectEdlPermissions = async () => {
+  try {
+    // get session token to use in spatial search query
+    const session = await Session.getCurrent();
+    if (session === null) {
+      throw new Error('No current session');
+    }
+    const authToken = await session.getAccessToken();
+    if (authToken === null) {
+      throw new Error('Failed to get authentication token');
+    }
+
+    const polygonUrlString = '&polygon[]=-49.921875,68.58850924263909,-50.06469726562501,68.56844733448305,-50.06469726562501,68.52223694881727,-49.91638183593751,68.52424806853186,-49.921875,68.58850924263909'
+    const spatialSearchUrl = `https://cmr.earthdata.nasa.gov/search/granules?collection_concept_id=${spatialSearchCollectionConceptId}${polygonUrlString}&page_size=${spatialSearchResultLimit}`
+    const userHasCorrectEdlPermissions = await fetch(spatialSearchUrl, {
+      method: 'GET',
+      credentials: 'omit',
+      headers: {
+        Authorization: `Bearer ${authToken}`
+      }
+    }).then(response => response.text()).then(data => {
+      const parser = new DOMParser();
+      const xml = parser.parseFromString(data, "application/xml");
+      const userHasCorrectEdlPermissions = parseInt(xml.getElementsByTagName("hits")[0].textContent ?? '0') > 0
+      return userHasCorrectEdlPermissions
+    })
+    return userHasCorrectEdlPermissions
+  } catch (err) {
+    if (err instanceof Error) {
+        // return err
+        return false
+      } else {
+        // return 'something happened'
+        return false
+      }
+  }
+}
+
 export default function AuthorizationCodeHandler(): ReactElement {
   const dispatch = useAppDispatch();
   const [searchParams] = useSearchParams();

--- a/src/components/history/GeneratedProductHistory.tsx
+++ b/src/components/history/GeneratedProductHistory.tsx
@@ -145,7 +145,12 @@ const GeneratedProductHistory = () => {
     }
 
     const renderProductHistoryViews = () => {
-        return userProducts.length === 0  ? productHistoryAlert() : renderHistoryTable()
+        return (
+            <Col>
+                <Row>{renderHistoryTable()}</Row>
+                {userProducts.length === 0 ? <Row>{productHistoryAlert()}</Row> : null}
+            </Col>
+        )
     }
 
     return (

--- a/src/components/history/GeneratedProductHistory.tsx
+++ b/src/components/history/GeneratedProductHistory.tsx
@@ -46,6 +46,32 @@ const GeneratedProductHistory = () => {
            <InfoCircle/>
         </OverlayTrigger>
     )
+
+    const renderCopyDownloadButton = (downloadUrlString: string) => (
+        <OverlayTrigger
+            placement="bottom"
+            overlay={
+                <Tooltip id="button-tooltip">
+                    Copy
+                </Tooltip>
+            }
+        >
+            <Button onClick={() => handleCopyClick(downloadUrlString as string)}><Clipboard color="white" size={18}/></Button>
+        </OverlayTrigger>
+    )
+
+    const renderDownloadButton = (downloadUrlString: string) => (
+        <OverlayTrigger
+            placement="bottom"
+            overlay={
+                <Tooltip id="button-tooltip">
+                    Download
+                </Tooltip>
+            }
+        >
+            <Button onClick={() => window.open(downloadUrlString, '_blank', 'noreferrer')}><Download color="white" size={18}/></Button>
+        </OverlayTrigger>
+    )
     
       const renderColTitle = (labelEntry: string[], index: number) => {
         let infoIcon = infoIconsToRender.includes(labelEntry[0]) ? renderInfoIcon(labelEntry[0]) : null
@@ -82,10 +108,10 @@ const GeneratedProductHistory = () => {
                                 if (entry[0] === 'downloadUrl' && entry[1] !== 'N/A') {
                                     const downloadUrlString = granules[0].uri
                                     cellContents = 
-                                    <Row>
+                                    <Row className='normal-row'>
                                         <Col>{entry[1]}</Col>
-                                        <Col><Button onClick={() => handleCopyClick(downloadUrlString as string)}><Clipboard color="white" size={18}/></Button></Col>
-                                        <Col><Button onClick={() => window.open(downloadUrlString, '_blank', 'noreferrer')}><Download color="white" size={18}/></Button></Col>
+                                        <Col>{(renderCopyDownloadButton(downloadUrlString))}</Col>
+                                        <Col>{renderDownloadButton(downloadUrlString)}</Col>
                                     </Row>
                                 } else {
                                     cellContents = entry[1]
@@ -124,7 +150,7 @@ const GeneratedProductHistory = () => {
 
     return (
         <>
-        <Row className='normal-row' style={{marginTop: '70px'}}><h4>Generated Products Data</h4></Row>
+        <h4 className='normal-row' style={{marginTop: '70px'}}>Generated Products Data</h4>
         <Col className='about-page' style={{marginRight: '50px', marginLeft: '50px'}}>
             <Row className='normal-row'>{waitingForProductsToLoad ? waitingForProductsToLoadSpinner() : renderProductHistoryViews()}</Row>
         </Col>

--- a/src/components/history/GeneratedProductHistory.tsx
+++ b/src/components/history/GeneratedProductHistory.tsx
@@ -1,4 +1,4 @@
-import { Alert, Col, OverlayTrigger, Row, Table, Tooltip, Button } from "react-bootstrap";
+import { Alert, Col, OverlayTrigger, Row, Table, Tooltip, Button, Spinner } from "react-bootstrap";
 import { useAppSelector } from "../../redux/hooks";
 import { getUserProductsResponse, Product } from "../../types/graphqlTypes";
 import { useEffect, useState } from "react";
@@ -12,10 +12,14 @@ const GeneratedProductHistory = () => {
     const { search } = useLocation();
     const navigate = useNavigate()
     const [userProducts, setUserProducts] = useState<Product[]>([])
+    const [waitingForProductsToLoad, setWaitingForProductsToLoad] = useState(true)
     
     useEffect(() => {
         const fetchData = async () => {
-            const userProductsResponse: getUserProductsResponse = await getUserProducts()
+            const userProductsResponse: getUserProductsResponse = await getUserProducts().then((response) => {
+                setWaitingForProductsToLoad(false)
+                return response
+            })
             if (userProductsResponse.status === 'success') setUserProducts(userProductsResponse.products as Product[])
         }
         fetchData()
@@ -103,20 +107,28 @@ const GeneratedProductHistory = () => {
         return <Col style={{margin: '30px'}}><Alert variant='warning' onClick={() => navigate(`/generatedProductHistory${search}`)} style={{cursor: 'pointer'}}>{alertMessage}</Alert></Col>
     }
 
-    const renderProductHistoryViews = () => {
+    const waitingForProductsToLoadSpinner = () => {
         return (
-            <Col style={{marginRight: '50px', marginLeft: '50px', marginTop: '70px', height: '100%', width: '100%'}}>
-                <Row className='normal-row' style={{marginRight: '0px'}}><h4>Generated Products Data</h4></Row>
-                <Row className='normal-row' style={{marginRight: '0px'}}>{renderHistoryTable()}</Row>
-                {userProducts.length === 0 ? <Row className='normal-row' style={{marginRight: '0px'}}>{productHistoryAlert()}</Row> : null}
-            </Col>
+            <div>
+                <h5>Loading Data Table...</h5>
+                <Spinner animation="border" role="status">
+                    <span className="visually-hidden">Loading...</span>
+                </Spinner> 
+            </div>
         )
     }
 
+    const renderProductHistoryViews = () => {
+        return userProducts.length === 0  ? productHistoryAlert() : renderHistoryTable()
+    }
+
     return (
-        <Row className='about-page' style={{marginRight: '0%'}}>
-            {renderProductHistoryViews()}
-        </Row>
+        <>
+        <Row className='normal-row' style={{marginTop: '70px'}}><h4>Generated Products Data</h4></Row>
+        <Col className='about-page' style={{marginRight: '50px', marginLeft: '50px'}}>
+            <Row className='normal-row'>{waitingForProductsToLoad ? waitingForProductsToLoadSpinner() : renderProductHistoryViews()}</Row>
+        </Col>
+        </>
     );
 }
 

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -30,7 +30,7 @@ const UpdateMapCenter = () => {
   // put the current center and zoom into the url parameters
   const handleMapFocus = (center: number[], zoom: number) => {
     const currentSearchParams = Object.fromEntries(searchParams.entries())
-    currentSearchParams.center = `${center[0]}_${center[1]}`
+    currentSearchParams.center = `${center[0]},${center[1]}`
     currentSearchParams.zoom = String(zoom)
     setSearchParams(currentSearchParams)
     dispatch(setMapFocus({center, zoom}))
@@ -64,14 +64,17 @@ const WorldMap = () => {
     const center = searchParams.get('center')
     const zoom = searchParams.get('zoom')
     if (center && zoom) {
-      const centerParamSplit = center.split('_')
+      const centerParamSplit = center.split(',')
       const centerToUse: number[] = [parseFloat(centerParamSplit[0]), parseFloat(centerParamSplit[1])]
       const zoomToUse = parseInt(zoom)
       if (centerToUse !== mapFocus.center || zoomToUse !== mapFocus.zoom) {
         dispatch(setMapFocus({center: centerToUse, zoom: zoomToUse}))
       }
     }
-    
+
+    // TODO: implement search polygon search param
+    // const searchPolygon = searchParams.get('searchPolygon')
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -118,7 +121,6 @@ const WorldMap = () => {
         const responseText = await data.text()
         // TODO: make subsequent calls to get granules in spatial search area till everything is found.
         // current issue is that 1000 (2000 total divided by 2) is limited by the cmr api.
-        // const responseHeaders = data.headers
         const parser = new DOMParser();
         const xml = parser.parseFromString(responseText, "application/xml");
         const references: SpatialSearchResult[] = Array.from(new Set(Array.from(xml.getElementsByTagName("name")).map(nameElement => {
@@ -142,9 +144,17 @@ const WorldMap = () => {
   }
 
   const onCreate = async (createEvent: any) => {
-      await getScenesWithinCoordinates([createEvent.layer.getLatLngs()[0]])
-      // set the new map focus location to what it was when polygon created so it will stay the same after map reload
-      dispatch(setMapFocus({center: [createEvent.layer._renderer._center.lat, createEvent.layer._renderer._center.lng], zoom: createEvent.target._zoom}))
+    const searchPolygonLatLngs = createEvent.layer.getLatLngs()[0]
+    
+    // TODO: implement search polygon search param
+    // const currentSearchParams = Object.fromEntries(searchParams.entries())
+    // const searchPolygonLatLngsString = searchPolygonLatLngs.map((latLngObject: {lat: number, lng: number}) => `${latLngObject.lat},${latLngObject.lng}`).join('_')
+    // currentSearchParams.searchPolygon = searchPolygonLatLngsString
+    // setSearchParams(currentSearchParams)
+
+    await getScenesWithinCoordinates([searchPolygonLatLngs])
+    // set the new map focus location to what it was when polygon created so it will stay the same after map reload
+    dispatch(setMapFocus({center: [createEvent.layer._renderer._center.lat, createEvent.layer._renderer._center.lng], zoom: createEvent.target._zoom}))
   }
 
   const onEdit = async (editEvent: any) => {

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -54,6 +54,7 @@ const ChangeView = () => {
 const WorldMap = () => {
   const addedProducts = useAppSelector((state) => state.product.addedProducts)
   const mapFocus = useAppSelector((state) => state.product.mapFocus)
+  const userHasCorrectEdlPermissions = useAppSelector((state) => state.app.userHasCorrectEdlPermissions)
   const dispatch = useAppDispatch()
   const footprintStyleOptions = { color: 'limegreen' }
     // search parameters
@@ -170,7 +171,7 @@ const WorldMap = () => {
         id='spatial-search-map'  
         zoom={7} scrollWheelZoom={true} zoomControl={false} 
       >
-          {useLocation().pathname.includes('selectScenes') ? (
+          {(useLocation().pathname.includes('selectScenes') && userHasCorrectEdlPermissions) ? (
             <FeatureGroup>
               <EditControl 
                 position="topright" 

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -86,7 +86,6 @@ const WorldMap = () => {
       if (authToken === null) {
         throw new Error('Failed to get authentication token');
       }
-
       dispatch(setWaitingForSpatialSearch(true))
 
       const polygonUrlString = coordinatesToSearch.map((polygon) => {
@@ -115,9 +114,13 @@ const WorldMap = () => {
         headers: {
           Authorization: `Bearer ${authToken}`
         }
-      }).then(response => response.text()).then(data => {
+      }).then(async data => {
+        const responseText = await data.text()
+        // TODO: make subsequent calls to get granules in spatial search area till everything is found.
+        // current issue is that 1000 (2000 total divided by 2) is limited by the cmr api.
+        // const responseHeaders = data.headers
         const parser = new DOMParser();
-        const xml = parser.parseFromString(data, "application/xml");
+        const xml = parser.parseFromString(responseText, "application/xml");
         const references: SpatialSearchResult[] = Array.from(new Set(Array.from(xml.getElementsByTagName("name")).map(nameElement => {
           return (nameElement.textContent)?.match(`${beforeCPS}([0-9]+(_[0-9]+)+)(${afterCPSR}|${afterCPSL})`)?.[1]
         }))).map(foundIdString => {
@@ -180,6 +183,12 @@ const WorldMap = () => {
             attribution='Esri, Maxar, Earthstar Geographics, and the GIS User Community'
             maxZoom = {18}
             noWrap
+            bounds={
+              [
+                [-89.9999, -179.9999],
+                [89.9999, 179.9999]
+              ]
+            }
           />
           <UpdateMapCenter />
           <ChangeView />

--- a/src/components/navbar/PodaacFooter.tsx
+++ b/src/components/navbar/PodaacFooter.tsx
@@ -2,9 +2,11 @@ import Navbar from 'react-bootstrap/Navbar';
 import { useAppSelector } from '../../redux/hooks'
 import { Col, Row } from 'react-bootstrap';
 import { useLocation, useNavigate } from 'react-router-dom';
+import packageJson from '../../../package.json'
 
 const PodaacFooter = () => {
   const colorModeClass = useAppSelector((state) => state.navbar.colorModeClass)
+  const userAuthenticated = useAppSelector((state) => state.app.userAuthenticated)
   const navigate = useNavigate();
   const { search } = useLocation();
 
@@ -12,7 +14,7 @@ const PodaacFooter = () => {
     <Navbar className={`${colorModeClass}-navbar-background Main-navbar fixed-bottom`} style={{paddingTop: '0px', paddingBottom: "0px", marginRight: '0px'}} expand="lg">
       <Row style={{width: '100%', paddingTop: '5px', paddingBottom: '5px'}}>
         <Col md={{ span: 6, offset: 0 }}><Navbar.Text style={{marginLeft: '0px', color: '#C8C7C5'}}>
-          Version 1.0 Pre-Alpha of SWOT On-Demand Level-2 Raster Generator (SWODLR)
+          {`Version ${packageJson.version} Pre-Alpha of SWOT On-Demand Level-2 Raster Generator (SWODLR)`}
         </Navbar.Text>
         </Col>
         <Col md={{ span: 5, offset: 1 }}><Row>       
@@ -21,11 +23,14 @@ const PodaacFooter = () => {
               <a href="https://www.jpl.nasa.gov/caltechjpl-privacy-policies-and-important-notices" target="_blank" style={{color: 'white'}} rel="noreferrer">Privacy</a>
             </Navbar.Text>
           </Col>
-          <Col>
-            <Navbar.Text style={{marginLeft: '0px', color: 'white', cursor: 'pointer'}} onClick={() => navigate(`/about${search}`)}>
-              <u>About SWODLR</u>
-            </Navbar.Text>
-          </Col>
+          { userAuthenticated ?
+            (<Col>
+              <Navbar.Text style={{marginLeft: '0px', color: 'white', cursor: 'pointer'}} onClick={() => navigate(`/about${search}`)}>
+                <u>About SWODLR</u>
+              </Navbar.Text>
+            </Col>) 
+            : null
+          }
           <Col>
             <Navbar.Text className={`${colorModeClass}-navbar-link`} style={{marginLeft: '0px', color: 'white', cursor: 'pointer'}} onClick={() => window.open('mailto:podaac@podaac.jpl.nasa.gov')}>
               <u>Contact</u>

--- a/src/components/navbar/PodaacFooter.tsx
+++ b/src/components/navbar/PodaacFooter.tsx
@@ -14,7 +14,7 @@ const PodaacFooter = () => {
     <Navbar className={`${colorModeClass}-navbar-background Main-navbar fixed-bottom`} style={{paddingTop: '0px', paddingBottom: "0px", marginRight: '0px'}} expand="lg">
       <Row style={{width: '100%', paddingTop: '5px', paddingBottom: '5px'}}>
         <Col md={{ span: 6, offset: 0 }}><Navbar.Text style={{marginLeft: '0px', color: '#C8C7C5'}}>
-          {`Version ${packageJson.version} Pre-Alpha of SWOT On-Demand Level-2 Raster Generator (SWODLR)`}
+          {`Version ${packageJson.version} Beta of SWOT On-Demand Level-2 Raster Generator (SWODLR)`}
         </Navbar.Text>
         </Col>
         <Col md={{ span: 5, offset: 1 }}><Row>       

--- a/src/components/sidebar/CustomizeProductView.tsx
+++ b/src/components/sidebar/CustomizeProductView.tsx
@@ -1,6 +1,7 @@
 import GranuleTable from './GranulesTable';
 import ProductCustomization from './ProductCustomization';
 import GenerateProducts from './GenerateProducts';
+import GranuleTableAlerts from './GranuleTableAlerts';
 
 const GranuleSelectionView = () => {
   return (
@@ -9,6 +10,8 @@ const GranuleSelectionView = () => {
       <GranuleTable tableType='productCustomization'/>
       <hr></hr>
       <GenerateProducts />
+      <GranuleTableAlerts tableType='productCustomization'/>
+
     </>
   );
 }

--- a/src/components/sidebar/CustomizeProductsSidebar.tsx
+++ b/src/components/sidebar/CustomizeProductsSidebar.tsx
@@ -47,6 +47,7 @@ const CustomizeProductsSidebar = (props: CustomizeProductSidebarProps) => {
         setLocalSidebarWidth(sidebarWidthNumber)
         setSidebarWidth(sidebarWidthNumber)
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [resizeEndLocation])
 
   return (
@@ -57,8 +58,6 @@ const CustomizeProductsSidebar = (props: CustomizeProductSidebarProps) => {
             {renderSidebarContents()}
             </div>
         </Col>
-
-        {/* TODO: uncomment when granule footprints are being retrieved to display on map */}
         <div className='sidebar-resize shadow'  onMouseDown={(event) => handleResizeClickDown(event)}>
             <ArrowsExpand className="sidebar-resize-icon icon-flipped" color="white" size={24} onMouseDown={(event) => handleResizeClickDown(event)}/>
         </div>

--- a/src/components/sidebar/DeleteGranulesModal.tsx
+++ b/src/components/sidebar/DeleteGranulesModal.tsx
@@ -15,7 +15,12 @@ const GenerateProductsModal = () => {
     const removeCPSFromUrl = (cpsCombosToRemove: string[]) => {
         const cyclePassSceneParameters = searchParams.get('cyclePassScene')?.split('-')
         if (cyclePassSceneParameters) {
-            const cyclePassSceneParametersToKeep = cyclePassSceneParameters.filter(cpsCombo => !cpsCombosToRemove.includes(cpsCombo)).join('-')
+            const cyclePassSceneParametersToKeep = cyclePassSceneParameters.filter(cpsCombo => {
+                const urlCPSSplit = cpsCombo.split('_')
+                const reconstructedUrlCPS = `${urlCPSSplit[0]}_${urlCPSSplit[1]}_${urlCPSSplit[2]}`
+                const keepCPSCombo = !cpsCombosToRemove.includes(reconstructedUrlCPS)
+                return keepCPSCombo
+            }).join('-')
             const currentUrlParameters = Object.fromEntries(searchParams.entries())
             if (cyclePassSceneParametersToKeep.length === 0) {
                 const {cyclePassScene, ...restOfCurrentUrlParameters} = currentUrlParameters

--- a/src/components/sidebar/GenerateProductsModal.tsx
+++ b/src/components/sidebar/GenerateProductsModal.tsx
@@ -2,18 +2,26 @@ import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 import { useAppSelector, useAppDispatch } from '../../redux/hooks'
 import { setShowGenerateProductModalFalse } from './actions/modalSlice'
-import { addGeneratedProducts } from './actions/productSlice'
+import { addGeneratedProducts, addGranuleTableAlerts } from './actions/productSlice'
 import { Row } from 'react-bootstrap';
+import { granuleAlertMessageConstant } from '../../constants/rasterParameterConstants';
+import { alertMessageInput } from '../../types/constantTypes';
 
 const GenerateProductsModal = () => {
     const showGenerateProductModal = useAppSelector((state) => state.modal.showGenerateProductModal)
     const addedGranules = useAppSelector((state) => state.product.addedProducts)
     const dispatch = useAppDispatch()
 
+    const setSaveGranulesAlert = (alert: alertMessageInput, additionalParameters?: any[]) => {
+        const {message, variant} = granuleAlertMessageConstant[alert]
+        dispatch(addGranuleTableAlerts({type: alert, message, variant, tableType: 'productCustomization' }))
+      }
+
     const handleGenerate = () => {
         // unselect select-all box
         dispatch(addGeneratedProducts(addedGranules.map(granuleObj => granuleObj.granuleId)))
         dispatch(setShowGenerateProductModalFalse())
+        setSaveGranulesAlert('successfullyGenerated')
     }
 
   return (

--- a/src/components/sidebar/GranuleSelectionAndConfigurationView.tsx
+++ b/src/components/sidebar/GranuleSelectionAndConfigurationView.tsx
@@ -8,14 +8,16 @@ import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 const GranuleSelectionAndConfigurationView = (props: GranuleSelectionAndConfigurationViewProps) => {
   const dispatch = useAppDispatch()
   const skipTutorial = useAppSelector((state) => state.modal.skipTutorial)
+  const userAuthenticated = useAppSelector((state) => state.app.userAuthenticated)
   const {mode} = props
   
   useEffect(() => {
-    if (!skipTutorial) {
+    if (!skipTutorial && userAuthenticated) {
       dispatch(setShowTutorialModalTrue())
       dispatch(setSkipTutorialTrue())
     }
-  }, []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userAuthenticated]);
 
   return (
     <>

--- a/src/components/sidebar/GranuleSelectionAndConfigurationView.tsx
+++ b/src/components/sidebar/GranuleSelectionAndConfigurationView.tsx
@@ -4,6 +4,8 @@ import WorldMap from '../map/WorldMap'
 import { setShowTutorialModalTrue, setSkipTutorialTrue } from './actions/modalSlice';
 import { useEffect } from 'react';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import { checkUseHasCorrectEdlPermissions } from '../edl/AuthorizationCodeHandler';
+import { setUserHasCorrectEdlPermissions } from '../app/appSlice';
 
 const GranuleSelectionAndConfigurationView = (props: GranuleSelectionAndConfigurationViewProps) => {
   const dispatch = useAppDispatch()
@@ -12,12 +14,22 @@ const GranuleSelectionAndConfigurationView = (props: GranuleSelectionAndConfigur
   const {mode} = props
   
   useEffect(() => {
+    const fetchData = async () => {
+      const userHasCorrectEdlPermissions = await checkUseHasCorrectEdlPermissions()
+      dispatch(setUserHasCorrectEdlPermissions(userHasCorrectEdlPermissions))
+    }
+
+    // call the function
+    fetchData()
+  }, [])
+
+  useEffect(() => {
     if (!skipTutorial && userAuthenticated) {
       dispatch(setShowTutorialModalTrue())
       dispatch(setSkipTutorialTrue())
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userAuthenticated]);
+  }, [userAuthenticated])
 
   return (
     <>

--- a/src/components/sidebar/GranuleSelectionView.tsx
+++ b/src/components/sidebar/GranuleSelectionView.tsx
@@ -1,3 +1,4 @@
+import { Alert, Col, Row } from 'react-bootstrap';
 import GranuleTable from './GranulesTable';
 import GranuleTableAlerts from './GranuleTableAlerts';
 import SpatialSearchOptions from './SpatialSearchOptions';
@@ -8,6 +9,13 @@ const GranuleSelectionView = () => {
         <SpatialSearchOptions />
         <GranuleTable tableType='granuleSelection'/>
         <GranuleTableAlerts tableType='granuleSelection'/>
+        <div style={{padding: '0px 20px 0px 20px'}} id='alert-messages'>
+            <Row style={{paddingTop: '5px', paddingBottom: '10px'}}>
+              <Col md={{ span: 8, offset: 2 }}>
+                <Alert variant={'warning'}>The SWOT dataset is not public yet. Until then, some functionality of this site will be limited. You are not yet able to add scenes, configure scenes, or generate products.</Alert>
+              </Col>
+            </Row>
+        </div>
     </div>
   );
 }

--- a/src/components/sidebar/GranuleSelectionView.tsx
+++ b/src/components/sidebar/GranuleSelectionView.tsx
@@ -7,7 +7,7 @@ const GranuleSelectionView = () => {
     <div>
         <SpatialSearchOptions />
         <GranuleTable tableType='granuleSelection'/>
-        <GranuleTableAlerts />
+        <GranuleTableAlerts tableType='granuleSelection'/>
     </div>
   );
 }

--- a/src/components/sidebar/GranuleSelectionView.tsx
+++ b/src/components/sidebar/GranuleSelectionView.tsx
@@ -2,20 +2,26 @@ import { Alert, Col, Row } from 'react-bootstrap';
 import GranuleTable from './GranulesTable';
 import GranuleTableAlerts from './GranuleTableAlerts';
 import SpatialSearchOptions from './SpatialSearchOptions';
+import { useAppSelector } from '../../redux/hooks';
 
 const GranuleSelectionView = () => {
+  const userHasCorrectEdlPermissions = useAppSelector((state) => state.app.userHasCorrectEdlPermissions)
   return (
     <div>
         <SpatialSearchOptions />
         <GranuleTable tableType='granuleSelection'/>
         <GranuleTableAlerts tableType='granuleSelection'/>
-        <div style={{padding: '0px 20px 0px 20px'}} id='alert-messages'>
-            <Row style={{paddingTop: '5px', paddingBottom: '10px'}}>
-              <Col md={{ span: 8, offset: 2 }}>
-                <Alert variant={'warning'}>The SWOT dataset is not public yet. Until then, some functionality of this site will be limited. You are not yet able to add scenes, configure scenes, or generate products.</Alert>
-              </Col>
-            </Row>
-        </div>
+        {
+          userHasCorrectEdlPermissions ? 
+            null : 
+            <div style={{padding: '0px 20px 0px 20px'}} id='alert-messages'>
+              <Row style={{paddingTop: '5px', paddingBottom: '10px'}}>
+                <Col md={{ span: 8, offset: 2 }}>
+                  <Alert variant={'warning'}>The SWOT dataset is not public yet. Until then, some functionality of this site will be limited. You are not yet able to add scenes, configure scenes, or generate products.</Alert>
+                </Col>
+              </Row>
+            </div>
+        }
     </div>
   );
 }

--- a/src/components/sidebar/GranuleTableAlerts.tsx
+++ b/src/components/sidebar/GranuleTableAlerts.tsx
@@ -1,13 +1,14 @@
 import { useAppSelector } from '../../redux/hooks'
 import { Alert, Col, Row } from 'react-bootstrap';
 import DeleteGranulesModal from './DeleteGranulesModal';
+import { TableTypes } from '../../types/constantTypes';
 
-const GranuleTableAlerts = () => {
+const GranuleTableAlerts: React.FC<{tableType: TableTypes}> = ({tableType}) => {
   const granuleTableAlerts = useAppSelector((state) => state.product.granuleTableAlerts)
 
   return (
     <div style={{padding: '0px 20px 0px 20px'}} id='alert-messages'>
-      {granuleTableAlerts.map((alertObject, index) => (
+      {granuleTableAlerts.filter(item => item.tableType === tableType).map((alertObject, index) => (
         <Row key={`${alertObject.variant}-${index}`} style={{paddingTop: '5px', paddingBottom: '10px'}}>
           <Col md={{ span: 8, offset: 2 }}>
             <Alert variant={`${alertObject.variant}`} dismissible>{alertObject.message}</Alert>

--- a/src/components/sidebar/GranulesTable.tsx
+++ b/src/components/sidebar/GranulesTable.tsx
@@ -47,7 +47,7 @@ const GranuleTable = (props: GranuleTableProps) => {
       })
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tableType === 'granuleSelection' ? null : addedProducts, searchParams])
+  }, [tableType === 'granuleSelection' ? null : addedProducts, startTutorial ? searchParams : null])
   
   const validateSceneAvailability = async (cycleToUse: number, passToUse: number, sceneToUse: number[], cpsList?: {cycle: string, pass: string, scene: string}[]): Promise<validScene> => {
     try {
@@ -210,9 +210,6 @@ const GranuleTable = (props: GranuleTableProps) => {
 
   const setSaveGranulesAlert = (alert: alertMessageInput, additionalParameters?: any[]) => {
     const {message, variant} = granuleAlertMessageConstant[alert]
-    if(alert === 'someSuccess') {
-
-    }
     dispatch(addGranuleTableAlerts({type: alert, message, variant, tableType: 'granuleSelection' }))
   }
 

--- a/src/components/sidebar/GranulesTable.tsx
+++ b/src/components/sidebar/GranulesTable.tsx
@@ -26,6 +26,7 @@ const GranuleTable = (props: GranuleTableProps) => {
   const spatialSearchStartDate = useAppSelector((state) => state.product.spatialSearchStartDate)
   const spatialSearchEndDate = useAppSelector((state) => state.product.spatialSearchEndDate)
   const startTutorial = useAppSelector((state) => state.app.startTutorial)
+  const userHasCorrectEdlPermissions = useAppSelector((state) => state.app.userHasCorrectEdlPermissions)
 
   const dispatch = useAppDispatch()
   
@@ -745,7 +746,7 @@ const GranuleTable = (props: GranuleTableProps) => {
                 <Spinner animation="border" role="status">
                   <span className="visually-hidden">Loading...</span>
                 </Spinner> : 
-                <Button variant='primary' size='sm' disabled={addedProducts.length >= granuleTableLimit || (cycle === '' || pass === '' || scene === '')} onClick={() => handleSave('manual', 1, 1)}>
+                <Button variant='primary' size='sm' disabled={addedProducts.length >= granuleTableLimit || (cycle === '' || pass === '' || scene === '') || !userHasCorrectEdlPermissions} onClick={() => handleSave('manual', 1, 1)}>
                   <Plus size={28}/> Add Scenes
                 </Button>
               }

--- a/src/components/sidebar/SpatialSearchOptions.tsx
+++ b/src/components/sidebar/SpatialSearchOptions.tsx
@@ -81,20 +81,8 @@ const SpatialSearchOptions = () => {
           />
         </Col>
       </Row>
-      {/* <Row>
-        <Col>
-          <Button variant='primary' size='sm' onClick={() => console.log('run spatial search')}>
-            <Search size={10}/> Find Scenes on Map
-          </Button>
-        </Col>
-      </Row> */}
       <Row style={{marginLeft: '0px', marginRight: '0px'}}>
         <Col style={{}}>
-          {/* <Alert variant="secondary" style={{marginLeft: '20px', marginRight:'20px'}}>
-            <p>
-              Draw areas to search spatially on the map by using the controls on the top right
-            </p>
-          </Alert> */}
           <p>
             Draw areas to <b>search spatially</b> on the map by using the controls on the <b>top right</b>. The scene search will start once you finish drawing the search area shape.
           </p>

--- a/src/components/sidebar/actions/modalSlice.ts
+++ b/src/components/sidebar/actions/modalSlice.ts
@@ -10,6 +10,7 @@ interface AddCustomProductModalState {
     selectedGranules: string[],
     showTutorialModal: boolean,
     skipTutorial: boolean,
+    showCloseTutorialModal: boolean
 }
 
 // Define the initial state using that type
@@ -23,7 +24,8 @@ const initialState: AddCustomProductModalState = {
     // allProducts: this will be like a 'database' for the local state of all the products added
     // the key will be cycleId_passId_sceneId and the value will be a 'parameterOptionDefaults' type object
     sampleGranuleDataArray: [],
-    selectedGranules: []
+    selectedGranules: [],
+    showCloseTutorialModal: false
 }
 
 export const modalSlice = createSlice({
@@ -70,6 +72,12 @@ export const modalSlice = createSlice({
     },
     setSkipTutorialTrue: (state) => {
         state.skipTutorial = true
+    },
+    setShowCloseTutorialFalse: (state) => {
+        state.showCloseTutorialModal = false
+    },
+    setShowCloseTutorialTrue: (state) => {
+        state.showCloseTutorialModal = true
     }
   },
 })
@@ -87,7 +95,9 @@ export const {
     setShowTutorialModalFalse,
     setShowTutorialModalTrue,
     setSkipTutorialFalse,
-    setSkipTutorialTrue
+    setSkipTutorialTrue,
+    setShowCloseTutorialFalse,
+    setShowCloseTutorialTrue,
 } = modalSlice.actions
 
 export default modalSlice.reducer

--- a/src/components/sidebar/actions/modalSlice.ts
+++ b/src/components/sidebar/actions/modalSlice.ts
@@ -19,7 +19,7 @@ const initialState: AddCustomProductModalState = {
     showDeleteProductModal: false,
     showGenerateProductModal: false,
     showTutorialModal: false,
-    skipTutorial: true,
+    skipTutorial: false,
     // allProducts: this will be like a 'database' for the local state of all the products added
     // the key will be cycleId_passId_sceneId and the value will be a 'parameterOptionDefaults' type object
     sampleGranuleDataArray: [],

--- a/src/components/sidebar/actions/productSlice.ts
+++ b/src/components/sidebar/actions/productSlice.ts
@@ -18,15 +18,12 @@ interface GranuleState {
     showUTMAdvancedOptions: boolean,
     spatialSearchResults: SpatialSearchResult[],
     waitingForSpatialSearch: boolean,
-    waitingForFootprintSearch: boolean,
     spatialSearchStartDate: string,
     spatialSearchEndDate: string,
     mapFocus: MapFocusObject
 }
 
 const {name, cycle, pass, scene, ...generateProductParametersFiltered } = parameterOptionDefaults
-
-const date = new Date()
 
 // Define the initial state using that type
 const initialState: GranuleState = {
@@ -44,7 +41,6 @@ const initialState: GranuleState = {
     showUTMAdvancedOptions: false,
     spatialSearchResults: [],
     waitingForSpatialSearch: false,
-    waitingForFootprintSearch: false,
     spatialSearchStartDate: (new Date(2022, 11, 16)).toISOString(),
     spatialSearchEndDate: (new Date()).toISOString()
 }
@@ -137,9 +133,6 @@ export const productSlice = createSlice({
     setWaitingForSpatialSearch: (state, action: PayloadAction<boolean>) => {
       state.waitingForSpatialSearch = action.payload
     },
-    setWaitingForFootprintSearch: (state, action: PayloadAction<boolean>) => {
-      state.waitingForFootprintSearch = action.payload
-    },
     setSpatialSearchStartDate: (state, action: PayloadAction<string>) => {
       state.spatialSearchStartDate = action.payload
     },
@@ -162,7 +155,6 @@ export const {
     setShowUTMAdvancedOptions,
     addSpatialSearchResults,
     setWaitingForSpatialSearch,
-    setWaitingForFootprintSearch,
     setSpatialSearchStartDate,
     setSpatialSearchEndDate,
     setMapFocus,

--- a/src/components/sidebar/actions/productSlice.ts
+++ b/src/components/sidebar/actions/productSlice.ts
@@ -33,7 +33,7 @@ const initialState: GranuleState = {
     sampleGranuleDataArray: [],
     selectedGranules: [],
     granuleFocus: [33.854457, -118.709093],
-    mapFocus: {center: [33.854457, -118.709093], zoom: 7},
+    mapFocus: {center: [33.854457, -118.709093], zoom: 6},
     generatedProducts: [],
     generateProductParameters: generateProductParametersFiltered,
     granuleTableAlerts: [],

--- a/src/components/tutorial/InteractiveTutorialModalClose.tsx
+++ b/src/components/tutorial/InteractiveTutorialModalClose.tsx
@@ -1,0 +1,44 @@
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+import { useAppSelector, useAppDispatch } from '../../redux/hooks'
+import { setShowCloseTutorialFalse, setSkipTutorialTrue } from '../sidebar/actions/modalSlice'
+import { Row } from 'react-bootstrap';
+import { setStartTutorial } from '../app/appSlice';
+import { deleteProduct } from '../sidebar/actions/productSlice';
+import { useNavigate } from 'react-router-dom';
+
+const InteractiveTutorialModalClose = () => {
+    const showCloseTutorialModal = useAppSelector((state) => state.modal.showCloseTutorialModal)
+    const dispatch = useAppDispatch()
+    const navigate = useNavigate()
+    const addedProducts = useAppSelector((state) => state.product.addedProducts)
+
+    const handleCloseTutorial = () => {
+        dispatch(setSkipTutorialTrue())
+        dispatch(setStartTutorial(false))
+        dispatch(deleteProduct(addedProducts.map(product => product.granuleId)))
+        navigate(`/customizeProduct/selectScenes`)
+        dispatch(setShowCloseTutorialFalse())
+    }
+
+  return (
+    <Modal style={{zIndex: 2000}} show={showCloseTutorialModal} onHide={() => dispatch(setShowCloseTutorialFalse())}>
+    <Modal.Header className="modal-style" closeButton>
+        <Modal.Title>Exit Interactive Tutorial</Modal.Title>
+    </Modal.Header>
+
+    <Modal.Body className="modal-style">
+        <Row>
+            <h5>Are you sure you want to exit the tutorial?</h5>
+        </Row>
+    </Modal.Body>
+
+    <Modal.Footer>
+        <Button variant="secondary" onClick={() => dispatch(setShowCloseTutorialFalse())}>Back to Tutorial</Button>
+        <Button variant="danger" type="submit" onClick={() => handleCloseTutorial()}>Exit</Button>
+    </Modal.Footer>
+    </Modal>
+  );
+}
+
+export default InteractiveTutorialModalClose;

--- a/src/components/tutorial/tutorialConstants.ts
+++ b/src/components/tutorial/tutorialConstants.ts
@@ -138,7 +138,7 @@ export const tutorialSteps = [
     },
     {
       target: "#scenes-to-customize",
-      content: "This is this table showing the scenes you can customize. Also shown are the options which are scene specific which are not applied to all the scenes in the list.",
+      content: "This is the table showing the scenes you can customize. Also shown are the options which are scene specific which are not applied to all the scenes in the list.",
       disableBeacon: true,
       styles: {
           options: {

--- a/src/components/welcome/Welcome.tsx
+++ b/src/components/welcome/Welcome.tsx
@@ -29,7 +29,7 @@ const Welcome = () => {
 
   return (
       <Row style={{backgroundColor: '#3d5d82', width: '100%'}}>
-        <Row style={{marginTop: '6%', marginBottom: '0%'}}><h2 className='welcome-page-text'>SWOT On-demand Level-2 Raster Generator</h2></Row>
+        <Row style={{marginTop: '6%', marginBottom: '0%'}}><h2 className='welcome-page-text'>SWOT On-Demand Level-2 Raster Generator</h2></Row>
         <Row style={{marginTop: '5%', height: '100%'}}>
           <Col sm={6} style={{borderRight: 'solid'}}>
             <Row style={{marginTop: '10%'}}>

--- a/src/components/welcome/Welcome.tsx
+++ b/src/components/welcome/Welcome.tsx
@@ -29,7 +29,7 @@ const Welcome = () => {
 
   return (
       <Row style={{backgroundColor: '#3d5d82', width: '100%'}}>
-        <Row style={{marginTop: '6%', marginBottom: '0%'}}><h2 className='welcome-page-text'>SWOT Level-2 On-demand Raster Generator</h2></Row>
+        <Row style={{marginTop: '6%', marginBottom: '0%'}}><h2 className='welcome-page-text'>SWOT On-demand Level-2 Raster Generator</h2></Row>
         <Row style={{marginTop: '5%', height: '100%'}}>
           <Col sm={6} style={{borderRight: 'solid'}}>
             <Row style={{marginTop: '10%'}}>

--- a/src/constants/rasterParameterConstants.ts
+++ b/src/constants/rasterParameterConstants.ts
@@ -188,6 +188,10 @@ export const granuleAlertMessageConstant: granuleAlertMessageConstantType = {
     someSuccess: {
         message: `Successfully added some scenes.`,
         variant: 'success'
+    },
+    successfullyGenerated: {
+        message: `Successfully started product generation! Go to the 'My Data' page to track progress.`,
+        variant: 'success'
     }
   }
 

--- a/src/constants/rasterParameterConstants.ts
+++ b/src/constants/rasterParameterConstants.ts
@@ -192,6 +192,10 @@ export const granuleAlertMessageConstant: granuleAlertMessageConstantType = {
     successfullyGenerated: {
         message: `Successfully started product generation! Go to the 'My Data' page to track progress.`,
         variant: 'success'
+    },
+    spatialSearchAreaTooLarge: {
+        message: `The search area you have drawn on the map is too large. Please search a smaller area.`,
+        variant: 'warning'
     }
   }
 

--- a/src/constants/rasterParameterConstants.ts
+++ b/src/constants/rasterParameterConstants.ts
@@ -95,6 +95,8 @@ export const parameterOptionDefaults = {
     mgrsBandAdjust: '0',
 }
 
+export const granuleTableLimit = 10
+
 export const parameterHelp: ParameterHelp = {
     outputGranuleExtentFlag: `There are two sizing options for raster granules: nonoverlapping square (128 km x 128 km) or overlapping rectangular (256 km x 128 km). The rectangular granule extent is 64 km longer in along-track on both sides of the granule and can be useful for observing areas of interest near the along-track edges of the nonoverlapping granules without the need to stitch sequential granules together.`,
     outputSamplingGridType: `Specifies the type of the raster sampling grid. It can be either a Universal Transverse Mercator (UTM) grid or a geodetic latitude-longitude grid.`,
@@ -104,7 +106,8 @@ export const parameterHelp: ParameterHelp = {
     cycle: `The repeat orbit cycle number of the observation. SWOT’s orbit is 21 days and thus observations in the same 21-day orbit period would have the same cycle number.`,
     pass: `Predefined sections of the orbit between the maximum and minimum latitudes. SWOT has 584 passes in one cycle, split into ascending and descending passes`,
     scene: `Predefined 128 x 128 km squares of the SWOT observations.`,
-    status: `The processing status of your custom product. The status types are as follows: NEW, UNAVAILABLE, GENERATING, ERROR, READY, AVAILABLE`
+    status: `The processing status of your custom product. The status types are as follows: NEW, UNAVAILABLE, GENERATING, ERROR, READY, AVAILABLE`,
+    granuleTableLimit: `There is a limit of ${granuleTableLimit} scenes allowed to be added to the scene table at a time. This is to ensure our scene processing pipeline can handle the demand of all of SWODLR's users.`
 }
 
 export interface InputBounds {
@@ -128,8 +131,6 @@ scene: {
     max: 154
 }
 }
-
-export const granuleTableLimit = 10
 
 export const granuleAlertMessageConstant: granuleAlertMessageConstantType = {
     success: {
@@ -177,12 +178,16 @@ export const granuleAlertMessageConstant: granuleAlertMessageConstantType = {
         variant: 'danger',
     },
     granuleLimit: {
-        message: `You can only process ${granuleTableLimit} scenes at a time.`,
+        message: `You can only process ${granuleTableLimit} scenes at a time so some scenes could not be added.`,
         variant: 'danger'
     },
     notInTimeRange: {
         message: `Some scenes were not within the specified spatial search time range.`,
         variant: 'danger'
+    },
+    someSuccess: {
+        message: `Successfully added some scenes.`,
+        variant: 'success'
     }
   }
 

--- a/src/constants/rasterParameterConstants.ts
+++ b/src/constants/rasterParameterConstants.ts
@@ -194,7 +194,7 @@ export const granuleAlertMessageConstant: granuleAlertMessageConstantType = {
         variant: 'success'
     },
     spatialSearchAreaTooLarge: {
-        message: `The search area you have drawn on the map is too large. Please search a smaller area.`,
+        message: `The search area you've selected on the map is too large. Please choose a smaller area to search.`,
         variant: 'warning'
     }
   }

--- a/src/types/constantTypes.ts
+++ b/src/types/constantTypes.ts
@@ -137,7 +137,7 @@ export interface validScene {
   [key: string]: boolean
 }
 
-export type alertMessageInput = 'success' | 'alreadyAdded' | 'allScenesNotAvailable' | 'alreadyAddedAndNotFound' | 'noScenesAdded' | 'readyForGeneration' | 'invalidCycle' | 'invalidPass' | 'invalidScene' | 'invalidScene' | 'someScenesNotAvailable' | 'granuleLimit' | 'notInTimeRange' | 'noScenesFound'
+export type alertMessageInput = 'success' | 'alreadyAdded' | 'allScenesNotAvailable' | 'alreadyAddedAndNotFound' | 'noScenesAdded' | 'readyForGeneration' | 'invalidCycle' | 'invalidPass' | 'invalidScene' | 'invalidScene' | 'someScenesNotAvailable' | 'granuleLimit' | 'notInTimeRange' | 'noScenesFound' | 'someSuccess'
 
 export interface SpatialSearchResult {
   cycle: string,

--- a/src/types/constantTypes.ts
+++ b/src/types/constantTypes.ts
@@ -137,7 +137,7 @@ export interface validScene {
   [key: string]: boolean
 }
 
-export type alertMessageInput = 'success' | 'alreadyAdded' | 'allScenesNotAvailable' | 'alreadyAddedAndNotFound' | 'noScenesAdded' | 'readyForGeneration' | 'invalidCycle' | 'invalidPass' | 'invalidScene' | 'invalidScene' | 'someScenesNotAvailable' | 'granuleLimit' | 'notInTimeRange' | 'noScenesFound' | 'someSuccess' | 'successfullyGenerated'
+export type alertMessageInput = 'success' | 'alreadyAdded' | 'allScenesNotAvailable' | 'alreadyAddedAndNotFound' | 'noScenesAdded' | 'readyForGeneration' | 'invalidCycle' | 'invalidPass' | 'invalidScene' | 'invalidScene' | 'someScenesNotAvailable' | 'granuleLimit' | 'notInTimeRange' | 'noScenesFound' | 'someSuccess' | 'successfullyGenerated' | 'spatialSearchAreaTooLarge'
 
 export interface SpatialSearchResult {
   cycle: string,

--- a/src/types/constantTypes.ts
+++ b/src/types/constantTypes.ts
@@ -137,7 +137,7 @@ export interface validScene {
   [key: string]: boolean
 }
 
-export type alertMessageInput = 'success' | 'alreadyAdded' | 'allScenesNotAvailable' | 'alreadyAddedAndNotFound' | 'noScenesAdded' | 'readyForGeneration' | 'invalidCycle' | 'invalidPass' | 'invalidScene' | 'invalidScene' | 'someScenesNotAvailable' | 'granuleLimit' | 'notInTimeRange' | 'noScenesFound' | 'someSuccess'
+export type alertMessageInput = 'success' | 'alreadyAdded' | 'allScenesNotAvailable' | 'alreadyAddedAndNotFound' | 'noScenesAdded' | 'readyForGeneration' | 'invalidCycle' | 'invalidPass' | 'invalidScene' | 'invalidScene' | 'someScenesNotAvailable' | 'granuleLimit' | 'notInTimeRange' | 'noScenesFound' | 'someSuccess' | 'successfullyGenerated'
 
 export interface SpatialSearchResult {
   cycle: string,


### PR DESCRIPTION
### Fixes
- There are not enough refreshes while performing spatial search which results in url state bugs
- Too many alerts when doing spatial search
- Duplicate Products (granules) display when generating products, and duplicates fails  w/ 'ERROR' status (when using the map spatial search option (BBOX))
- When generating products using map spatial search option (BBOX), various warnings display while scenes are being retrieved / added ("The scenes entered are not available." "Some scenes entered are not available.")
- The 'About SWODLR' hyperlink on main page (footer) non-functional (note: UI main page prior to Earthdata Login)
- Warning displays when navigating to or refreshing the 'My Data' page in UI:  "No product have been generated. Go  to the Products Customization page to generate products 
- User was not able to successfully Add Scene when using Cycle (001), but was able to add scene as expected using Cycle (1). Entering a 3 digit cycle seems to be an issue (E.g., try adding scene for cycle:001, pass:414, scene23 or cycle:007, pass:072, scene13-14).  note: also not able to successfully Add Scene using 3-digit Scene (022 or 023), but was able to add scene as expected using Scene (23 or 22).
- 'Configure Products' should not be an option after adding scenes in UI, as this configuration already occurred via Select Scene 'Configure Options'  (top of the Customization page in UI)
- Customization page in UI - user unable to delete Added Scenes. When refreshing the page after added scenes removed/deleted, the deleted scenes re-appear in SWODLR UI **FIX:** remove url param when deleting from table
- Customization page in UI - Map sizing issues. The size of map should remain in place. The Map in UI should not randomly re-size (e.g., after sizing, and navigating through menus, and back to customization page w/ map or when refreshing the page)
- 'My Data' page in UI:  (user only can only view / display 10 rows of generated data in UI) Generated Products Data do not retain in UI (Should pagination or page numbers be Implemented ?)
- 'Configure Options / Products'  page - advanced options 'Scenes to Customize' - User unable to toggle or select all of the row options for UTM Zone Adjust or MGRS Band Adjust
- Tutorial modal does now start when you click the Tutorial navbar button when on certain pages.
- The 'Back' function does not work as expected for tutorial pages (12/18), (16/18). The tutorial crashes/exits. For tutorial page (17/18), try the 'Back' and then 'Next' to see the issue (blank screen displays if navigating back to Customization/About tabs after selecting 'Next; If user selects the MyData page after selecting 'Next', the tutorial window re-appears w/ tutorial page (18/18)))
- speed up spatial search load time
- tutorial back button crashes site
- Can’t change adjust of spatial search granules (SIT) (I am not able to reproduce in SIT. It is working in SIT for me.)
- About page in UI: the 'original algorithm' hyperlink triggers an Invalid Key error (waiting on email back from Alexander Corben with the working link)
- 10 scene granule limit
- Spinner running too long
- added version numbers to footer and about page
- Map stays at same location after refresh (not including search polygons)
- Can re-run tutorial successfully now after fully completing first tutorial
- Outside of the map bounds it says "map data not yet available"




__________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________

**_David C.'s comments: 02/20/2024_**

SWODLR (SIT/UAT) UIs:
SWODLR UI: 1.0.0-rc.8
SWODLR API: 0.0.1-alpha48
_note: 
Some of the listed issues are also documented in related UI Bug Fixes ticket: 
https://github.com/podaac/swodlr-ui/issues/72_


- There are not enough refreshes while performing spatial search which results in url state bugs
**OK- This issue appears to be currently resolved**

- Too many alerts when doing spatial search
**OK- This issue appears to be currently resolved**

- Duplicate Products (granules) display when generating products, and duplicates fails  w/ 'ERROR' status (when using the map spatial search option (BBOX))
**OK- in SWODLR UIs - Duplicate Products no longer display**

- When generating products using map spatial search option (BBOX), various warnings display while scenes are being retrieved / added ("The scenes entered are not available." "Some scenes entered are not available.")
**OK- in SWODLR UIs**

- The 'About SWODLR' hyperlink on main page (footer) non-functional (note: UI main page prior to Earthdata Login)
**OK- This issue is now resolved - the'About SWODLR' hyperlink on main page (footer) was removed accordingly (note: UI main page prior to Earthdata Login)**

- Warning displays when navigating to or refreshing the 'My Data' page in UI:  "No product have been generated. Go  to the Products Customization page to generate products 
**Pending Fix- This Issue still exists in SWODLR SIT/UAT**

- User was not able to successfully Add Scene when using Cycle (001), but was able to add scene as expected using Cycle (1). Entering a 3 digit cycle seems to be an issue (E.g., try adding scene for cycle:001, pass:414, scene23 or cycle:007, pass:072, scene13-14).  note: also not able to successfully Add Scene using 3-digit Scene (022 or 023), but was able to add scene as expected using Scene (23 or 22).
**OK- This issue appears to be currently resolved in SWODLR SIT/UAT**

- 'Configure Products' should not be an option after adding scenes in UI, as this configuration already occurred via Select Scene 'Configure Options'  (top of the Customization page in UI)
**OK- This issue is resolved - the 'Configure Products' screen is no longer in the UI. User must now use the 'Configure Options' screen prior to Generating Products - resolved in SWODLR SIT/UAT**

- Customization page in UI - user unable to delete Added Scenes. When refreshing the page after added scenes removed/deleted, the deleted scenes re-appear in SWODLR UI **FIX:** remove url param when deleting from table
**OK- This issue appears to be currently resolved in SWODLR SIT/UAT**

- Customization page in UI - Map sizing issues. The size of map should remain in place. The Map in UI should not randomly re-size (e.g., after sizing, and navigating through menus, and back to customization page w/ map or when refreshing the page)
**The map seems to remain in place now after refreshing  UI accordingly . 
But, note: a created Polygon (BBOX) disappears from UI. note2: the MAP in UI should be more of a rectangular shape instead of the current small, square shape**

- 'My Data' page in UI:  (user only can only view / display 10 rows of generated data in UI) Generated Products Data do not retain in UI (Should pagination or page numbers be Implemented ?)
**OK- Verified that the user only can now view more than 10 rows of generated data on 'My Data' page in SWODLR SIT/UAT UI.
NOTE: SWODLR UI still needs pagination and page numbers implemented. Table sorting and/or page limit(s) needed as well (E.g. Show 20 per page, Show 50 per page, Show 100 per page, etc) - related issues in GIThub:
https://github.com/podaac/swodlr-ui/issues/70
https://github.com/podaac/swodlr-ui/issues/71**

- 'Configure Options / Products'  page - advanced options 'Scenes to Customize' - User unable to toggle or select all of the row options for UTM Zone Adjust or MGRS Band Adjust
**OK - This issue appears to be currently resolved in SWODLR SIT/UAT.**

- Tutorial modal does now start when you click the Tutorial navbar button when on certain pages.
**OK- This tutorial modal bug seems to be okay at this time.** 

- The 'Back' function does not work as expected for tutorial pages (12/18), (16/18). The tutorial crashes/exits. For tutorial page (17/18), try the 'Back' and then 'Next' to see the issue (blank screen displays if navigating back to Customization/About tabs after selecting 'Next; If user selects the MyData page after selecting 'Next', the tutorial window re-appears w/ tutorial page (18/18)))
**OK- This tutorial modal bug seems to be okay at this time. 
Note: still have tutorial modal issue where the tutorial goes back to the Scenes to customize page in lieu of the My Data page.  Happens when back-paging from tutorial page (16/17) to (15/17)**

- speed up spatial search load time
**OK- This issue appears to be currently resolved**

- tutorial back button crashes site
**OK- back button crashes are no longer occurring
Note: still have tutorial modal issue where the tutorial goes back to the Scenes to customize page in lieu of the My Data page. This happened when back-paging from page (16/17) to (15/17)**

- Can’t change adjust of spatial search granules (SIT) (I am not able to reproduce in SIT. It is working in SIT for me.)
**OK- This issue appears to be currently resolved**

- About page in UI: the 'original algorithm' hyperlink triggers an Invalid Key error (waiting on email back from Alexander Corben with the working link)
**OK- This issue is now resolved - the original algorithm Hyperlink no longer shows an error when selected**

- 10 scene granule limit
**OK- The 10 scene granule limit now seems to function as expected. No more than 10 rows of Added scenes can be currently accepted in UI**

- Spinner running too long
**OK-  it seems like this issue is okay now, the spinner no longer takes a while to finish after scenes are added**

- added version numbers to footer and about page
**Confirmed that version information was added to the About page (and in the footer in UI).
note: Still need to remove the 'Version History' info from the About page**

- Map stays at same location after refresh (not including search polygons)
**Confirmed that the map seems to remain in place now after refresh accordingly. 
But, note: a user created Polygon (BBOX) disappears from UI**

- Can re-run tutorial successfully now after fully completing first tutorial
**OK- This 're-run tutorial' modal issue is currently resolved**

- Outside of the map bounds it says "map data not yet available"
**OK- This issue is now resolved
note: the MAP in UI should be more of a rectangular shape instead of the current small, square shape  (e.g., when map is minimized)**